### PR TITLE
fix infinite loop in hook.py

### DIFF
--- a/pinax/messages/hooks.py
+++ b/pinax/messages/hooks.py
@@ -8,9 +8,10 @@ class DefaultHookSet(object):
 
 
 class HookProxy(object):
+    _settings = None
 
     def load_settings(self):
-        if not hasattr(self, "_settings"):
+        if self._settings is None:
             from .conf import settings
             self._settings = settings
 


### PR DESCRIPTION
There is an infinite loop in settings loading in python 3.5 django 1.9.
I didn't test the problem or the fix on other environnements

Fixes #9