### PR TITLE
fix thread urls in urls

### DIFF
--- a/pinax/messages/urls.py
+++ b/pinax/messages/urls.py
@@ -7,6 +7,6 @@ urlpatterns = patterns(
     url(r"^inbox/$", views.InboxView.as_view(), name="messages_inbox"),
     url(r"^create/$", views.message_create, name="message_create"),
     url(r"^create/(?P<user_id>\d+)/$", views.message_create, name="message_create"),
-    url(r"^thread/(?P<thread_id>\d+)/$", views.ThreadView.as_view(), name="messages_thread_detail"),
+    url(r"^thread/(?P<pk>\d+)/$", views.ThreadView.as_view(), name="messages_thread_detail"),
     url(r"^thread/(?P<thread_id>\d+)/delete/$", views.thread_delete, name="messages_thread_delete"),
 )


### PR DESCRIPTION
There was an error when trying to access to ThreadView.
ClassBasedView request for a pk or slug attribute in urls
Rename thread_id to pk in urls.py

Fixes #11