### PR TITLE
Update 'Getting Started' section of README

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ Luke Hatcher
 Michele Mattioni
 Issac Kelly
 Arthur Maire
+Vicky Leong

--- a/README.rst
+++ b/README.rst
@@ -43,15 +43,19 @@ Getting Started
 Include ``pinax-messages`` in your requirements file and add
 ``"pinax.messages"`` to your INSTALLED APPS setting.
 
-Once you have the ``pinax-messages`` installed, hook up the URLs::
+Run Django migration (``python manage.py migrate``) so that
+your project recognizes this new app.
 
-    urlpatterns = patterns("",
+Once you have the ``pinax-messages`` installed and migrated,
+hook up the URLs::
+
+    urlpatterns = [
         # some cool URLs
 
-        (r"^messages/", include("pinax.messages.urls", namespace="pinax_messages")),
+        url(r"^messages/", include("pinax.messages.urls", namespace="pinax_messages")),
 
         # some other cool URLs
-    )
+    ]
 
 Now all you need to do is wire up some templates.
 

--- a/README.rst
+++ b/README.rst
@@ -43,8 +43,8 @@ Getting Started
 Include ``pinax-messages`` in your requirements file and add
 ``"pinax.messages"`` to your INSTALLED APPS setting.
 
-Run Django migration (``python manage.py migrate``) so that
-your project recognizes this new app.
+Run Django migration (``python manage.py migrate``) so that the
+database creates the necessary tables for ``pinax-messages``.
 
 Once you have the ``pinax-messages`` installed and migrated,
 hook up the URLs::


### PR DESCRIPTION
`django.conf.urls.patterns` is deprecated. The code already uses
`django.conf.urls.url`, but the documentation doesn't reflect that.

Part of solution for #24 