### PR TITLE
Add `unread_thread_count` filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,24 @@ For instance if there are unread messages in a thread, change the CSS class acco
     </div>
 ```
 
+### unread_thread_count
+
+Returns the number of unread threads for the user. Use for notifying a user of new messages, for example in _account_bar.html
+
+**Argument**: `user`
+
+For instance if there are unread messages in a thread, change the CSS class accordingly:
+
+```html
+{% load pinax_messages_tags %}
+
+    <li class="{% if user|unread_threads %}unread{% endif %}">
+        <a href="{% url 'pinax_messages:inbox' %}"><i class="fa fa-envelope"></i> {% trans "Messages" %}
+            {% if user|unread_threads %}<sup>{{ user|unread_threads }}</sup>{% endif %}
+        </a>
+    </li>        
+```
+
 ## Reference Guide
 
 ### URL–View–Template Matrix

--- a/pinax/messages/templatetags/pinax_messages_tags.py
+++ b/pinax/messages/templatetags/pinax_messages_tags.py
@@ -1,8 +1,21 @@
 from django import template
 
+from pinax.messages.models import Thread
+
 register = template.Library()
 
 
 @register.filter
 def unread(thread, user):
+    """
+    Check whether there are any unread messages for a particular thread for a user.
+    """
     return bool(thread.userthread_set.filter(user=user, unread=True))
+
+
+@register.filter
+def unread_thread_count(user):
+    """
+    Return the number of Threads with unread messages for this user, useful for highlighting on an account bar for example.
+    """
+    return Thread.unread(user).count()

--- a/pinax/messages/tests/tests.py
+++ b/pinax/messages/tests/tests.py
@@ -236,6 +236,72 @@ class TestTemplateTags(BaseTest):
             "READ",
         )
 
+    def test_unread_thread_count_one_unread(self):
+        """
+        Ensure `unread_threads` template_tag produces correct results for one unread message
+        """
+        thread = Message.new_message(
+            self.brosner,
+            [self.jtauber],
+            "Why did you break the internet?", "I demand to know.").thread
+
+        tmpl = """
+               {% load pinax_messages_tags %}
+               {% if user|unread_thread_count %}{{ user|unread_thread_count }}{% endif %}
+               """
+        self.assert_renders(
+            tmpl,
+            Context({"thread": thread, "user": self.jtauber}),
+            "1"
+        )
+
+    def test_unread_thread_count_two_messages_incl_reply(self):
+        """
+        Ensure `unread_threads` template_tag produces correct results.
+        """
+        thread = Message.new_message(
+            self.brosner,
+            [self.jtauber],
+            "Why did you break the internet?", "I demand to know.").thread
+
+        Message.new_reply(thread, self.jtauber, "Replying to the first message")
+        Message.new_reply(thread, self.brosner, "Replying again, so that there are two unread messages on one thread")
+
+        thread = Message.new_message(
+            self.brosner,
+            [self.jtauber],
+            "Second message", "So there are two.").thread
+        tmpl = """
+               {% load pinax_messages_tags %}
+               {% if user|unread_thread_count %}{{ user|unread_thread_count }}{% endif %}
+               """
+        self.assert_renders(
+            tmpl,
+            Context({"thread": thread, "user": self.jtauber}),
+            "2"
+        )
+
+    def test_unread_thread_count_with_all_messages_read(self):
+        """
+        Ensure `unread_threads` template_tag produces correct results.
+        """
+        thread = Message.new_message(
+            self.brosner,
+            [self.jtauber],
+            "Why did you break the internet?", "I demand to know.").thread
+
+        Message.new_reply(thread, self.jtauber, "Replying to the message so that I have no unread Threads")
+
+        tmpl = """
+               {% load pinax_messages_tags %}
+               {{ user|unread_thread_count }}
+               """
+        self.assert_renders(
+            tmpl,
+            Context({"thread": thread, "user": self.jtauber}),
+            "0"
+        )
+
 
 class TestHookSet(BaseTest):
     def test_get_user_choices(self):

--- a/pinax/messages/tests/tests.py
+++ b/pinax/messages/tests/tests.py
@@ -240,7 +240,7 @@ class TestTemplateTags(BaseTest):
         """
         Ensure `unread_threads` template_tag produces correct results for one unread message
         """
-        thread = Message.new_message(
+        Message.new_message(
             self.brosner,
             [self.jtauber],
             "Why did you break the internet?", "I demand to know.").thread
@@ -251,7 +251,7 @@ class TestTemplateTags(BaseTest):
                """
         self.assert_renders(
             tmpl,
-            Context({"thread": thread, "user": self.jtauber}),
+            Context({"user": self.jtauber}),
             "1"
         )
 
@@ -267,7 +267,7 @@ class TestTemplateTags(BaseTest):
         Message.new_reply(thread, self.jtauber, "Replying to the first message")
         Message.new_reply(thread, self.brosner, "Replying again, so that there are two unread messages on one thread")
 
-        thread = Message.new_message(
+        Message.new_message(
             self.brosner,
             [self.jtauber],
             "Second message", "So there are two.").thread
@@ -277,7 +277,7 @@ class TestTemplateTags(BaseTest):
                """
         self.assert_renders(
             tmpl,
-            Context({"thread": thread, "user": self.jtauber}),
+            Context({"user": self.jtauber}),
             "2"
         )
 
@@ -298,7 +298,7 @@ class TestTemplateTags(BaseTest):
                """
         self.assert_renders(
             tmpl,
-            Context({"thread": thread, "user": self.jtauber}),
+            Context({"user": self.jtauber}),
             "0"
         )
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     description="a reusable private user messages application for Django",
     name="pinax-messages",
     long_description=LONG_DESCRIPTION,
-    version="1.1.0",
+    version="1.2.0",
     url="http://github.com/pinax/pinax-messages/",
     license="MIT",
     packages=find_packages(),


### PR DESCRIPTION
Based on @mattlindesay work in https://github.com/pinax/pinax-messages/pull/35.

Filter is renamed to `unread_thread_count` to avoid name conflict with existing context variable `unread_threads` populated by the pinax-messages context processor. Otherwise unchanged. Thanks @mattlindesay!