### PR TITLE
Allow the ability to send to groups as well as users

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Django apps, themes, and starter project templates. This collection can be found
 
 Django \ Python | 2.7 | 3.4 | 3.5 | 3.6
 --------------- | --- | --- | --- | ---
-1.11 |  *  |  *  |  *  |  *  
+1.11 |  *  |  *  |  *  |  *
 2.0  |     |  *  |  *  |  *
 
 
@@ -153,6 +153,18 @@ The following context variables are available, and work with the current authent
 * `inbox_threads` — all message threads for current user
 * `unread_threads` — unread message threads for current user
 
+#### Overriding forms
+
+You can override the form used to create and send the message by passing the form object in as kwargs:
+
+```python
+    from pinax.messages.forms import NewMessageFormMultipleGroup, NewMessageFormMultiple
+
+    url(r"^messages/create/$", MessageCreateView.as_view(),
+        {'form': NewMessageFormMultipleGroup}, name="message_create"),
+    url(r"^messages/create/(?P<user_id>\d+)/$", MessageCreateView.as_view(),
+        {'form': NewMessageFormMultiple}, name="message_user_create"),
+```
 
 ### Template Tags and Filters
 
@@ -188,7 +200,7 @@ For instance if there are unread messages in a thread, change the CSS class acco
         <a href="{% url 'pinax_messages:inbox' %}"><i class="fa fa-envelope"></i> {% trans "Messages" %}
             {% if user_unread %}<sup>{{ user_unread }}</sup>{% endif %}
         </a>
-    </li>        
+    </li>
     {% endwith %}
 ```
 

--- a/pinax/messages/forms.py
+++ b/pinax/messages/forms.py
@@ -67,7 +67,15 @@ class NewMessageFormMultiple(forms.ModelForm):
         fields = ["to_user", "subject", "content"]
 
 
-class NewMessageFormGroup(forms.ModelForm):
+class NewMessageFormMultipleGroup(forms.ModelForm):
+    """
+        This form provides the ability to send to both multiple users and
+        multiple groups.
+
+        If a group or groups are selected, a lookup is performed to get all users
+        from the group(s) and send that list to Message.new_message().  If a user
+        or multiple users are also selected the user(s) will be added to the list.
+    """
     subject = forms.CharField()
     to_user = UserModelMultipleChoiceField(get_user_model().objects.none(),
         required=False)
@@ -77,7 +85,7 @@ class NewMessageFormGroup(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop("user")
-        super(NewMessageFormGroup, self).__init__(*args, **kwargs)
+        super(NewMessageFormMultipleGroup, self).__init__(*args, **kwargs)
         self.fields["to_user"].queryset = hookset.get_user_choices(self.user)
         if self.initial.get("to_user") is not None:
             qs = self.fields["to_user"].queryset.filter(pk__in=self.initial["to_user"])
@@ -88,7 +96,7 @@ class NewMessageFormGroup(forms.ModelForm):
             self.fields["to_group"].queryset = qs
 
     def clean(self):
-        cleaned_data = super(NewMessageFormGroup, self).clean()
+        cleaned_data = super(NewMessageFormMultipleGroup, self).clean()
         to_user = cleaned_data.get('to_user')
         to_group = cleaned_data.get('to_group')
 

--- a/pinax/messages/forms.py
+++ b/pinax/messages/forms.py
@@ -1,8 +1,12 @@
 from django import forms
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.db.models.query import QuerySet
 
 from .hooks import hookset
 from .models import Message
+
+from itertools import chain
 
 
 class UserModelChoiceField(forms.ModelChoiceField):
@@ -15,6 +19,12 @@ class UserModelMultipleChoiceField(forms.ModelMultipleChoiceField):
 
     def label_from_instance(self, obj):
         return hookset.display_name(obj)
+
+
+# class GroupModelMultipleChoiceField(forms.ModelMultipleChoiceField):
+
+#     def label_from_instance(self, obj):
+#         return hookset.display_name(obj)
 
 
 class NewMessageForm(forms.ModelForm):
@@ -64,6 +74,57 @@ class NewMessageFormMultiple(forms.ModelForm):
     class Meta:
         model = Message
         fields = ["to_user", "subject", "content"]
+
+
+class NewMessageFormGroup(forms.ModelForm):
+    subject = forms.CharField()
+    to_user = UserModelMultipleChoiceField(get_user_model().objects.none(),
+        required=False)
+    to_group = forms.ModelMultipleChoiceField(queryset=Group.objects.all(),
+        required=False)
+    content = forms.CharField(widget=forms.Textarea)
+
+    def __init__(self, *args, **kwargs):
+        self.user = kwargs.pop("user")
+        super(NewMessageFormGroup, self).__init__(*args, **kwargs)
+        self.fields["to_user"].queryset = hookset.get_user_choices(self.user)
+        if self.initial.get("to_user") is not None:
+            qs = self.fields["to_user"].queryset.filter(pk__in=self.initial["to_user"])
+            self.fields["to_user"].queryset = qs
+
+        if self.initial.get("to_group") is not None:
+            qs = self.fields["to_group"].queryset.filter(pk__in=self.initial["to_group"])
+            self.fields["to_group"].queryset = qs
+
+    def clean(self):
+        cleaned_data = super(NewMessageFormGroup, self).clean()
+        to_user = cleaned_data.get('to_user')
+        to_group = cleaned_data.get('to_group')
+
+        if not to_user and not to_group:
+            msg = "Please select either some users or some groups"
+            self.add_error('to_user', msg)
+            self.add_error('to_group', msg)
+
+    def save(self, commit=True):
+        data = self.cleaned_data
+        users = None
+        if data['to_group']:
+            users = get_user_model().objects.filter(
+                groups__name__in=data['to_group'].values_list('name'))
+
+        if users:
+            sendto = data['to_user'].union(users)
+        else:
+            sendto = data['to_user']
+
+        return Message.new_message(
+            self.user, sendto, data["subject"], data["content"]
+        )
+
+    class Meta:
+        model = Message
+        fields = ["to_user", "to_group", "subject", "content"]
 
 
 class MessageReplyForm(forms.ModelForm):

--- a/pinax/messages/forms.py
+++ b/pinax/messages/forms.py
@@ -1,12 +1,9 @@
 from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
-from django.db.models.query import QuerySet
 
 from .hooks import hookset
 from .models import Message
-
-from itertools import chain
 
 
 class UserModelChoiceField(forms.ModelChoiceField):
@@ -19,12 +16,6 @@ class UserModelMultipleChoiceField(forms.ModelMultipleChoiceField):
 
     def label_from_instance(self, obj):
         return hookset.display_name(obj)
-
-
-# class GroupModelMultipleChoiceField(forms.ModelMultipleChoiceField):
-
-#     def label_from_instance(self, obj):
-#         return hookset.display_name(obj)
 
 
 class NewMessageForm(forms.ModelForm):

--- a/pinax/messages/views.py
+++ b/pinax/messages/views.py
@@ -8,7 +8,12 @@ from django.views.generic import (
     UpdateView
 )
 
-from .forms import MessageReplyForm, NewMessageForm, NewMessageFormMultiple
+from .forms import (
+    MessageReplyForm,
+    NewMessageForm,
+    NewMessageFormMultiple,
+    NewMessageFormGroup
+)
 from .models import Thread
 
 try:
@@ -89,6 +94,8 @@ class MessageCreateView(CreateView):
 
     def get_form_class(self):
         if self.form_class is None:
+            if self.kwargs.get("group", False):
+                return NewMessageFormGroup
             if self.kwargs.get("multiple", False):
                 return NewMessageFormMultiple
         return NewMessageForm

--- a/pinax/messages/views.py
+++ b/pinax/messages/views.py
@@ -12,7 +12,6 @@ from .forms import (
     MessageReplyForm,
     NewMessageForm,
     NewMessageFormMultiple,
-    NewMessageFormGroup
 )
 from .models import Thread
 
@@ -94,10 +93,11 @@ class MessageCreateView(CreateView):
 
     def get_form_class(self):
         if self.form_class is None:
-            if self.kwargs.get("group", False):
-                return NewMessageFormGroup
             if self.kwargs.get("multiple", False):
                 return NewMessageFormMultiple
+            form = self.kwargs.get("form", False)
+            if form:
+                return form
         return NewMessageForm
 
     def get_initial(self):


### PR DESCRIPTION
This PR allows you to specify using a send to group form.  This lets the end user select any number of users and/or groups to send the message to.