### PR TITLE
Allow urls to define new message form

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,19 @@ The following context variables are available, and work with the current authent
 * `inbox_threads` — all message threads for current user
 * `unread_threads` — unread message threads for current user
 
+#### Overriding forms
+
+You can override the form used to create and send the message by passing the form object in as kwargs:
+
+```python
+    from pinax.messages.forms import NewMessageFormMultipleGroup, NewMessageFormMultiple
+
+    path('messages/create/', MessageCreateView.as_view(),
+        {'form': NewMessageFormMultipleGroup}, name="message_create"),
+    path('messages/create/<int:user_id>/', MessageCreateView.as_view(),
+        {'form': NewMessageFormMultiple}, name="message_user_create"),
+```
+
 ### Template Tags and Filters
 
 #### unread
@@ -198,7 +211,7 @@ For instance if there are unread messages in a thread, change the CSS class acco
         <a href="{% url 'pinax_messages:inbox' %}"><i class="fa fa-envelope"></i> {% trans "Messages" %}
             {% if user_unread %}<sup>{{ user_unread }}</sup>{% endif %}
         </a>
-    </li>        
+    </li>
     {% endwith %}
 ```
 

--- a/pinax/messages/forms.py
+++ b/pinax/messages/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
 
 from .hooks import hookset
 from .models import Message
@@ -40,6 +41,65 @@ class NewMessageForm(forms.ModelForm):
     class Meta:
         model = Message
         fields = ["to_user", "subject", "content"]
+
+
+class NewMessageFormMultipleGroup(forms.ModelForm):
+    """
+        This form provides the ability to send to both multiple users and
+        multiple groups.
+
+        If a group or groups are selected, a lookup is performed to get all users
+        from the group(s) and send that list to Message.new_message().  If a user
+        or multiple users are also selected the user(s) will be added to the list.
+    """
+    subject = forms.CharField()
+    to_user = UserModelMultipleChoiceField(get_user_model().objects.none(),
+        required=False)
+    to_group = forms.ModelMultipleChoiceField(queryset=Group.objects.all(),
+        required=False)
+    content = forms.CharField(widget=forms.Textarea)
+
+    def __init__(self, *args, **kwargs):
+        self.user = kwargs.pop("user")
+        super(NewMessageFormMultipleGroup, self).__init__(*args, **kwargs)
+        self.fields["to_user"].queryset = hookset.get_user_choices(self.user)
+        if self.initial.get("to_user") is not None:
+            qs = self.fields["to_user"].queryset.filter(pk__in=self.initial["to_user"])
+            self.fields["to_user"].queryset = qs
+
+        if self.initial.get("to_group") is not None:
+            qs = self.fields["to_group"].queryset.filter(pk__in=self.initial["to_group"])
+            self.fields["to_group"].queryset = qs
+
+    def clean(self):
+        cleaned_data = super(NewMessageFormMultipleGroup, self).clean()
+        to_user = cleaned_data.get('to_user')
+        to_group = cleaned_data.get('to_group')
+
+        if not to_user and not to_group:
+            msg = "Please select either some users or some groups"
+            self.add_error('to_user', msg)
+            self.add_error('to_group', msg)
+
+    def save(self, commit=True):
+        data = self.cleaned_data
+        users = None
+        if data['to_group']:
+            users = get_user_model().objects.filter(
+                groups__name__in=data['to_group'].values_list('name'))
+
+        if users:
+            sendto = data['to_user'].union(users)
+        else:
+            sendto = data['to_user']
+
+        return Message.new_message(
+            self.user, sendto, data["subject"], data["content"]
+        )
+
+    class Meta:
+        model = Message
+        fields = ["to_user", "to_group", "subject", "content"]
 
 
 class NewMessageFormMultiple(forms.ModelForm):

--- a/pinax/messages/models.py
+++ b/pinax/messages/models.py
@@ -98,7 +98,7 @@ class Message(models.Model):
         thread = Thread.objects.create(subject=subject)
         for user in to_users:
             thread.userthread_set.create(user=user, deleted=False, unread=True)
-        thread.userthread_set.create(user=from_user, deleted=True, unread=False)
+        # thread.userthread_set.create(user=from_user, deleted=True, unread=False)
         msg = cls.objects.create(thread=thread, sender=from_user, content=content)
         message_sent.send(sender=cls, message=msg, thread=thread, reply=False)
         return msg

--- a/pinax/messages/signals.py
+++ b/pinax/messages/signals.py
@@ -1,3 +1,3 @@
 from django.dispatch import Signal
 
-message_sent = Signal(providing_args=["message", "thread", "reply"])
+message_sent = Signal("message", "thread", "reply")

--- a/pinax/messages/signals.py
+++ b/pinax/messages/signals.py
@@ -1,3 +1,3 @@
 from django.dispatch import Signal
 
-message_sent = Signal("message", "thread", "reply")
+message_sent = Signal()

--- a/pinax/messages/urls.py
+++ b/pinax/messages/urls.py
@@ -1,18 +1,18 @@
-from django.conf.urls import url
+from django.urls import path
 
 from . import views
 
 app_name = "pinax_messages"
 
 urlpatterns = [
-    url(r"^inbox/$", views.InboxView.as_view(),
+    path("inbox/", views.InboxView.as_view(),
         name="inbox"),
-    url(r"^create/$", views.MessageCreateView.as_view(),
+    path("create/", views.MessageCreateView.as_view(),
         name="message_create"),
-    url(r"^create/(?P<user_id>\d+)/$", views.MessageCreateView.as_view(),
+    path("create/<int:user_id>/", views.MessageCreateView.as_view(),
         name="message_user_create"),
-    url(r"^thread/(?P<pk>\d+)/$", views.ThreadView.as_view(),
+    path("thread/<int:pk>/", views.ThreadView.as_view(),
         name="thread_detail"),
-    url(r"^thread/(?P<pk>\d+)/delete/$", views.ThreadDeleteView.as_view(),
+    path("thread/<int:pk>/delete/", views.ThreadDeleteView.as_view(),
         name="thread_delete"),
 ]

--- a/pinax/messages/views.py
+++ b/pinax/messages/views.py
@@ -82,6 +82,7 @@ class MessageCreateView(CreateView):
     Create a new thread message.
     """
     template_name = "pinax/messages/message_create.html"
+    success_url = reverse_lazy("pinax_messages:inbox")
 
     @method_decorator(login_required)
     def dispatch(self, *args, **kwargs):

--- a/pinax/messages/views.py
+++ b/pinax/messages/views.py
@@ -89,8 +89,15 @@ class MessageCreateView(CreateView):
 
     def get_form_class(self):
         if self.form_class is None:
+            """ keeping for backwards compatibility """
             if self.kwargs.get("multiple", False):
                 return NewMessageFormMultiple
+
+            """ check to see if a form was defined in urls """
+            form = self.kwargs.get('form', False)
+            if form:
+                return form
+
         return NewMessageForm
 
     def get_initial(self):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-VERSION = "3.0.0"
+VERSION = "3.0.1"
 LONG_DESCRIPTION = """
 .. image:: http://pinaxproject.com/pinax-design/patches/pinax-messages.svg
     :target: https://pypi.python.org/pypi/pinax-messages/


### PR DESCRIPTION
Update for PR#48. Exact same function though. Give the ability to pass a form in from the defined url to add different capabilities. The group form is just an example of how this PR can help keep the app flexible. I could simply define a form in my project and pass that in to the url.